### PR TITLE
Fix bug in solution when calculating the homogenous global transformation matrix

### DIFF
--- a/src/e1/joint.py
+++ b/src/e1/joint.py
@@ -11,7 +11,7 @@ class Joint3D:
         """
         Initialize a 3D joint.
 
-        :param axis: Local axis of rotation/translation (must be a unit vector)
+        :param axis: Axis of rotation/translation (must be a unit vector) for this joint in global coordinates.
         :param length: Fixed length of the link
         :param parent: Parent joint (None for base)
         """

--- a/src/e1/joint.py
+++ b/src/e1/joint.py
@@ -11,7 +11,7 @@ class Joint3D:
         """
         Initialize a 3D joint.
 
-        :param axis: Axis of rotation/translation (must be a unit vector) for this joint in global coordinates.
+        :param axis: Local axis of rotation/translation (must be a unit vector) for this joint. When initially created, this joint uses the global coordinate system. Only when attached to a parent, the coordinate system becomes local.
         :param length: Fixed length of the link
         :param parent: Parent joint (None for base)
         """

--- a/src/e1/kinematics.py
+++ b/src/e1/kinematics.py
@@ -3,6 +3,7 @@
 Author: Steffen Peikert, steffen.peikert@fau.de
 Version & Changelog:
 - 1.0 (2025-04-28)
+- 1.1 (2025-05-01): Animation is now smooth
 """
 
 import argparse
@@ -15,32 +16,33 @@ from e1.solution.joint import animate_kinematic_chain
 
 def _main():
     base = base = RevoluteJoint3D([0, 0, 1], 0)
-    joint1 = RevoluteJoint3D(
+    joint1 = PrismaticJoint3D(
         axis_of_rotation=np.asarray([0, 0, 1]),
-        length_mm=5,
+        length_mm=3,
         parent=base,
     )
-    joint2 = PrismaticJoint3D(
+    joint2 = RevoluteJoint3D(
         axis_of_rotation=np.asarray([1, 0, 0]),
-        length_mm=10,
+        length_mm=1.5,
         parent=joint1,
     )
     joint3 = RevoluteJoint3D(
-        axis_of_rotation=np.asarray([0, 0, 1]),
-        length_mm=3,
+        axis_of_rotation=np.asarray([0, 1, 0]),
+        length_mm=1.5,
         parent=joint2,
     )
     end_effector = RevoluteJoint3D(
-        axis_of_rotation=np.asarray([0, 0, 1]),
+        axis_of_rotation=np.asarray([1, 1, 0]),
         length_mm=2,
         parent=joint3,
     )
 
     update_functions = [
-        lambda frame: np.radians(30 * np.sin(frame / 20)),  # Revolute joint oscillating
-        lambda frame: 2 + np.sin(frame / 20),  # Prismatic joint extending/retracting
-        lambda frame: np.radians(45 * np.cos(frame / 20)),  # Revolute joint oscillating
-        lambda frame: np.radians(0),  # Fixed ee, since we cannot see the rotation anyways
+        lambda frame: frame / 100 * np.pi,  # Base rotates around z axis
+        lambda frame: 3 + .5 * np.sin(frame / 100 * np.pi),  # prismatic joint extending/retracting
+        lambda frame: frame / 100 * np.pi,  # Revolute joint rotating around its axis
+        lambda frame: frame / 100 * np.pi,  # Revolute joint rotating around its axis
+        lambda frame: 0,  # Fixed ee, since we cannot see the rotation anyways
     ]
     animate_kinematic_chain(
         end_effector,

--- a/src/e1/solution/joint.py
+++ b/src/e1/solution/joint.py
@@ -29,9 +29,10 @@ class Joint3DSharedImpl(Joint3D):
         :return: 4x4 homogenous transformation matrix
         """
         if self.parent is None:
-            return np.eye(4)  # Identity matrix for base
+            parent_transform = np.eye(4)  # Identity matrix for base
+        else:
+            parent_transform = self.parent.get_cumulative_transformation(joint_configurations[:-1])
 
-        parent_transform = self.parent.get_cumulative_transformation(joint_configurations[:-1])
         local_transform = self.get_transformation_matrix(joint_configurations[-1])
 
         return parent_transform @ local_transform


### PR DESCRIPTION
- Fix bug in solution when calculating the homogenous global transformation matrix. In the old version, the homogenous transform was set to identity when no parent was found. This was neglecting the first joint in the chain. Now, instead of returning identity, the parent is assumed to be Identity and the local joint transform is still applied.
In conjunction, the default joints in the playground have been updated to better visualize the different joint axes (and look nicer).

- This PR fixes the jumpy (and rather random) animation.

- In addition, the axis parameter of Joint3D has been further clarified